### PR TITLE
do not register middlewares on /healthz path

### DIFF
--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -50,7 +50,7 @@ func NewRouter(conf *config.Config) *http.ServeMux {
 			handler = mw(handler)
 		}
 		for _, mw := range middlewares {
-			if route.Path == "/healthz" && conf.SkipHealthzLog {
+			if route.Path == "/healthz" {
 				continue
 			}
 			handler = mw(handler)

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -50,6 +50,9 @@ func NewRouter(conf *config.Config) *http.ServeMux {
 			handler = mw(handler)
 		}
 		for _, mw := range middlewares {
+			if route.Path == "/healthz" && conf.SkipHealthzLog {
+				continue
+			}
 			handler = mw(handler)
 		}
 		router.Handle(route.Path, handler)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	ScriptDir       string `flag:"scripts" desc:"Scripts location" default:"scripts"`
 	PasswdFile      string `flag:"passwd-file" desc:"Password file for basic HTTP authentication" default:".htpasswd"`
 	LogDir          string `flag:"log-dir" desc:"Hook execution logs location" default:""`
+	SkipHealthzLog  bool   `flag:"skip-healthz-log" desc:"Do not log on healthz request" default:"true"`
 	NotificationURI string `flag:"notification-uri" desc:"Notification URI"`
 	TrustStoreFile  string `flag:"trust-store-file" desc:"Trust store used by HTTP signature verifier (.pem or .p12)"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,6 @@ type Config struct {
 	ScriptDir       string `flag:"scripts" desc:"Scripts location" default:"scripts"`
 	PasswdFile      string `flag:"passwd-file" desc:"Password file for basic HTTP authentication" default:".htpasswd"`
 	LogDir          string `flag:"log-dir" desc:"Hook execution logs location" default:""`
-	SkipHealthzLog  bool   `flag:"skip-healthz-log" desc:"Do not log on healthz request" default:"true"`
 	NotificationURI string `flag:"notification-uri" desc:"Notification URI"`
 	TrustStoreFile  string `flag:"trust-store-file" desc:"Trust store used by HTTP signature verifier (.pem or .p12)"`
 }


### PR DESCRIPTION
~~I want to use webhookd `/healthz` endpoint on k8s livenessProbe or readinessProbe, so I needed to skip log on `/healthz` request.~~
do not use middlewares on `/healthz` path for use as k8s livenessProbe or readinessProbe.