### PR TITLE
Adding HTTP "PATCH" support to API calls

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -47,7 +47,7 @@ func routes(conf *config.Config) Routes {
 		route(
 			"/",
 			index,
-			middlewares.UseBefore(middleware.Methods("GET", "POST"))...,
+			middlewares.UseBefore(middleware.Methods("GET", "PATCH", "POST"))...,
 		),
 		route(
 			staticPath,

--- a/pkg/middleware/cors.go
+++ b/pkg/middleware/cors.go
@@ -8,7 +8,7 @@ import (
 func Cors(inner http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "PATCH, POST, GET, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization")
 
 		if r.Method != "OPTIONS" {


### PR DESCRIPTION

Would be really nice to support HTTP "PATCH" for API calls. Passing a "hook_method=PATCH" to the scripts would be nice as well.