### PR TITLE
feat(image): add "slim" variant of minimal-size image, with statically-compiled binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,25 @@ WORKDIR /go/src/$REPOSITORY/$ARTIFACT
 RUN make
 
 #########################################
+# "slim" Distribution stage
+#########################################
+FROM alpine:latest AS slim
+
+# Repository location
+ARG REPOSITORY=github.com/ncarlier
+
+# Artifact name
+ARG ARTIFACT=webhookd
+
+# Install binary *only*
+COPY --from=builder /go/src/$REPOSITORY/$ARTIFACT/release/$ARTIFACT /usr/local/bin/$ARTIFACT
+
+VOLUME [ "/scripts" ]
+EXPOSE 8080
+
+CMD [ "webhookd" ]
+
+#########################################
 # Distribution stage
 #########################################
 FROM docker:dind

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 build:
 	-mkdir -p release
 	echo "Building: $(EXECUTABLE) $(VERSION) for $(GOOS)-$(GOARCH) ..."
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "$(LDFLAGS)" -o release/$(EXECUTABLE)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -tags netgo -ldflags "$(LDFLAGS)" -o release/$(EXECUTABLE)
 .PHONY: build
 
 release/$(EXECUTABLE): build
@@ -66,6 +66,12 @@ install: release/$(EXECUTABLE)
 image:
 	echo "Building Docker image ..."
 	docker build --rm -t ncarlier/$(APPNAME) .
+.PHONY: image
+
+## Create "slim" Docker image
+image-slim:
+	echo "Building slim Docker image ..."
+	docker build --rm --target slim -t ncarlier/$(APPNAME)-slim .
 .PHONY: image
 
 ## Generate changelog


### PR DESCRIPTION
I had a particular use-case where I really needed _just_ webhookd, in as small of an image as I could reasonably expect, and I really didn't want to use `docker:dind`.  (I'm not sure what your use-case for `dind` is, but [the kind-of-canonical blog post about it](http://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/) suggests that you probably _don't_ actually want `dind`, you want the vanilla docker client with `/var/run/docker.sock` mounted instead.)

Rather than build a brand new image from scratch myself, I thought you might find it useful to offer this "slim" version as a variant.  (If it were me, I'd make the "small" version the base, and then add things like the "git clone" entrypoint as an extra.)  The additional Dockerfile stage is pretty simple; it's just `alpine:latest` and the `webhookd` binary, and expects the scripts to be mounted to `/scripts`, which is where webhookd already looks by default when `/` is the CWD.  There's a definite size advantage here, as well: the original `ncarlier/webhookd` image is 336MB on my machine, but `ncarlier/webhookd-slim` is **less than 15MB**.

In order to get `webhookd` to run on `alpine`, I did have to change webhookd to be built statically, using a non-C build and with the `netgo` tag to avoid use of the libc library.  Rather than add an additional, separate build of the binary, I just changed the main build settings in `Makefile`, which means the "regular" build is now statically compliled as well.  You may not want this; I won't be offended if you'd rather keep everything as is.
