### PR TITLE
chore(): fix mailto in default env file

### DIFF
--- a/etc/default/webhookd.env
+++ b/etc/default/webhookd.env
@@ -28,7 +28,7 @@
 #WHD_NB_WORKERS=2
 
 # Notification URI, disabled by default
-# Example: `http://requestb.in/v9b229v9` or `mailto://foo@bar.com?smtp=smtp-relay-localnet:25`
+# Example: `http://requestb.in/v9b229v9` or `mailto:foo@bar.com?smtp=smtp-relay-localnet:25`
 #WHD_NOTIFICATION_URI=
 
 # Password file for HTTP basic authentication, default is ".htpasswd"


### PR DESCRIPTION
The default env file's example for using mailto: is incorrect and doesn't match the README. If you actually try to use mailto:// then you'll get a malformed recipient address.

This PR is just to remove the double slashes.