### PR TITLE
Feature: add blocking request with response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,23 +83,33 @@ For example, you can execute a Node.js file if you give execution rights to the 
 You can find sample scripts in the [example folder](./scripts/examples).
 In particular, examples of integration with Gitlab and Github.
 
-### Webhook URL
+### Webhook call
 
 The directory structure define the webhook URL.
 
 You can omit the script extension. If you do, webhookd will search by default for a `.sh` file.
 You can change the default extension using the `WHD_HOOK_DEFAULT_EXT` environment variable or `-hook-default-ext` parameter.
-If the script exists, the output will be streamed to the HTTP response.
+If the script exists, the output will be send to the HTTP response.
 
-The streaming technology depends on the HTTP request:
+Depending on the HTTP request, the HTTP response will be a HTTP `200` code with the script's output in real time (streaming), or the HTTP response will wait until the end of the script's execution and return the output (tuncated) of the script as well as an HTTP code relative to the script's output code :
 
-- [Server-sent events][sse] is used when:
-  - Using `GET` verb
-  - Using `text/event-stream` in `Accept` request header
-- [Chunked Transfer Coding][chunked] is used otherwise.
+The streaming protocol depends on the HTTP request:
+
+- [Server-sent events][sse] is used when `Accept` HTTP header is equal to `text/event-stream`.
+- [Chunked Transfer Coding][chunked] is used when `X-Hook-TE` HTTP header is equal to `chunked`.
 
 [sse]: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events
 [chunked]: https://datatracker.ietf.org/doc/html/rfc2616#section-3.6.1
+
+If no streaming protocol is asked, the HTTP reponse block until the script is over:
+
+- Sends script output limited to the last 100 lines. You can modify this limit via the HTTP header `X-Hook-MaxOutputLines`.
+- Convert the script exit code to HTTP code as follow:
+  - 0: `200 OK`
+  - Between 1 and 99: `500 Internal Server Error`
+  - Between 100 and 255: Add 300 to get HTTP code between 400 and 555
+
+> Remember: a process exit code is between 0 and 255. 0 means that the execution is successful.
 
 *Example:*
 
@@ -110,21 +120,11 @@ The script: `./scripts/foo/bar.sh`
 
 echo "foo foo foo"
 echo "bar bar bar"
+
+exit 118
 ```
 
-Output using `POST` or `GET` (`Chunked Transfer Coding`):
-
-```bash
-$ curl -v -XPOST http://localhost:8080/foo/bar
-< HTTP/1.1 200 OK
-< Content-Type: text/plain; charset=utf-8
-< Transfer-Encoding: chunked
-< X-Hook-Id: 7
-foo foo foo
-bar bar bar
-```
-
-Output using  `GET` and `Accept` header (`Server-sent events`):
+Streamed output using  `Server-sent events`:
 
 ```bash
 $ curl -v --header "Accept: text/event-stream" -XGET http://localhost:8080/foo/bar
@@ -132,10 +132,43 @@ $ curl -v --header "Accept: text/event-stream" -XGET http://localhost:8080/foo/b
 < Content-Type: text/event-stream
 < Transfer-Encoding: chunked
 < X-Hook-Id: 8
+
 data: foo foo foo
 
 data: bar bar bar
+
+error: exit status 118
 ```
+
+Streamed output using `Chunked Transfer Coding`:
+
+```bash
+$ curl -v -XPOST --header "X-Hook-TE: chunked" http://localhost:8080/foo/bar
+< HTTP/1.1 200 OK
+< Content-Type: text/plain; charset=utf-8
+< Transfer-Encoding: chunked
+< X-Hook-Id: 7
+
+foo foo foo
+bar bar bar
+error: exit status 118
+
+```
+
+Blocking HTTP request:
+
+```bash
+$ curl -v -XPOST http://localhost:8080/foo/bar
+< HTTP/1.1 418 I m a teapot
+< Content-Type: text/plain; charset=utf-8
+< X-Hook-Id: 9
+
+foo foo foo
+bar bar bar
+error: exit status 118
+```
+
+> Note that in this last example the HTTP response is equal to `exit code + 300` : `318 I'm a teapot`.
 
 ### Webhook parameters
 
@@ -211,7 +244,7 @@ $ # Call webhook
 $ curl -v http://localhost:8080/echo?foo=bar
 ...
 < HTTP/1.1 200 OK
-< Content-Type: text/event-stream
+< Content-Type: text/plain
 < X-Hook-Id: 2
 ...
 $ # Retrieve logs afterwards

--- a/etc/default/webhookd.env
+++ b/etc/default/webhookd.env
@@ -19,6 +19,8 @@
 
 # Default extension for hook scripts, default is "sh"
 #WHD_HOOK_DEFAULT_EXT=sh
+# Default hook HTTP response mode (chunked or buffered), default is "chunked"
+#WHD_HOOK_DEFAULT_MODE=chunked
 # Maximum hook execution time in second, default is 10
 #WHD_HOOK_TIMEOUT=10
 # Scripts location, default is "scripts"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,11 +20,12 @@ type Config struct {
 
 // HookConfig store Hook execution configuration
 type HookConfig struct {
-	DefaultExt string `flag:"default-ext" desc:"Default extension for hook scripts" default:"sh"`
-	Timeout    int    `flag:"timeout" desc:"Maximum hook execution time in second" default:"10"`
-	ScriptsDir string `flag:"scripts" desc:"Scripts location" default:"scripts"`
-	LogDir     string `flag:"log-dir" desc:"Hook execution logs location" default:""`
-	Workers    int    `flag:"workers" desc:"Number of workers to start" default:"2"`
+	DefaultExt  string `flag:"default-ext" desc:"Default extension for hook scripts" default:"sh"`
+	DefaultMode string `flag:"default-mode" desc:"Hook default response mode (chuncked,buffered)" default:"chuncked"`
+	Timeout     int    `flag:"timeout" desc:"Maximum hook execution time in second" default:"10"`
+	ScriptsDir  string `flag:"scripts" desc:"Scripts location" default:"scripts"`
+	LogDir      string `flag:"log-dir" desc:"Hook execution logs location" default:""`
+	Workers     int    `flag:"workers" desc:"Number of workers to start" default:"2"`
 }
 
 // LogConfig store logger configuration

--- a/pkg/hook/logs.go
+++ b/pkg/hook/logs.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ncarlier/webhookd/pkg/helper"
 )
 
-// Logs get hook log with its name and id
-func Logs(id, name, base string) (*os.File, error) {
+// GetLogFile get hook log with its name and id
+func GetLogFile(id, name, base string) (*os.File, error) {
 	logPattern := path.Join(base, fmt.Sprintf("%s_%s_*.txt", helper.ToSnake(name), id))
 	files, err := filepath.Glob(logPattern)
 	if err != nil {

--- a/pkg/hook/test/job_test.go
+++ b/pkg/hook/test/job_test.go
@@ -46,7 +46,7 @@ func TestHookJob(t *testing.T) {
 
 	// Test that we can retrieve log file afterward
 	id := strconv.FormatUint(job.ID(), 10)
-	logFile, err := hook.Logs(id, "test", os.TempDir())
+	logFile, err := hook.GetLogFile(id, "test", os.TempDir())
 	assert.Nil(t, err, "Log file should exists")
 	defer logFile.Close()
 	assert.NotNil(t, logFile, "Log file should be retrieve")
@@ -70,6 +70,7 @@ func TestWorkRunnerWithError(t *testing.T) {
 	assert.NotNil(t, err, "")
 	assert.Equal(t, job.Status(), hook.Error, "")
 	assert.Equal(t, "exit status 1", err.Error(), "")
+	assert.Equal(t, 1, job.ExitCode(), "")
 }
 
 func TestWorkRunnerWithTimeout(t *testing.T) {

--- a/pkg/middleware/types.go
+++ b/pkg/middleware/types.go
@@ -8,7 +8,7 @@ type Middleware func(inner http.Handler) http.Handler
 // Middlewares list
 type Middlewares []Middleware
 
-// UseBefore insert a middleware at the begining of the middleware chain
+// UseBefore insert a middleware at the beginning of the middleware chain
 func (ms Middlewares) UseBefore(m Middleware) Middlewares {
 	return append([]Middleware{m}, ms...)
 }


### PR DESCRIPTION
You can now call a blocking webhook to obtain an HTTP response code relative to the script's output code.