### PR TITLE
fix(tests): make tests posix compatible

### DIFF
--- a/pkg/hook/test/test_error.sh
+++ b/pkg/hook/test/test_error.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Running error test script..."
 

--- a/pkg/hook/test/test_simple.sh
+++ b/pkg/hook/test/test_simple.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Running simple test script..."
 

--- a/pkg/hook/test/test_timeout.sh
+++ b/pkg/hook/test/test_timeout.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Running timeout test script..."
 
-for i in {1..5}; do
+for i in `seq 5`; do
   sleep .5
   echo "running..."
 done


### PR DESCRIPTION
Make tests run on `sh` rather than `bash`, this way the tests can pass on Alpine/busybox (maybe other distros as well) without the need of `bash`