### PR TITLE
chore(docker): add github-cli to distrib image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN adduser \
     "$USER"
 
 # Install deps
-RUN apk add --no-cache bash gcompat git openssl openssh-client curl jq docker-cli-compose aha
+RUN apk add --no-cache bash gcompat git openssl openssh-client curl jq docker-cli-compose aha github-cli
 
 # Install binary and entrypoint
 COPY --from=builder /go/src/$REPOSITORY/$ARTIFACT/release/$ARTIFACT /usr/local/bin/$ARTIFACT


### PR DESCRIPTION
Hi :)
really like this project.

Not sure if this is something you would like to include, but I would love to have the [Github CLI](https://cli.github.com/) available within the docker image.