### PR TITLE
feat(docker): customization of installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN adduser \
     "$USER"
 
 # Install deps
-RUN apk add --no-cache bash gcompat git openssl openssh-client curl jq docker-cli-compose aha
+RUN apk add --no-cache bash gcompat git openssl openssh-client curl jq docker-cli-compose aha su-exec
 
 # Install binary and entrypoint
 COPY --from=builder /go/src/$REPOSITORY/$ARTIFACT/release/$ARTIFACT /usr/local/bin/$ARTIFACT
@@ -90,6 +90,8 @@ VOLUME [ "/scripts" ]
 
 EXPOSE 8080
 
-USER $USER
+# Note: no USER directive here on purpose. The entrypoint starts as root so it
+# can install WHD_EXTRA_PACKAGES, then drops to the unprivileged $USER (via
+# su-exec) before running the server. The server and hook scripts never run as root.
 
 CMD [ "webhookd" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,29 @@
 # Error function
 die() { echo "error: $@" 1>&2 ; exit 1; }
 
+# When running as root, install any extra packages (this needs root and happens
+# once, at startup, before any webhook is served) then permanently drop to the
+# unprivileged webhookd user so the script clone and the server never run as root.
+if [ "$(id -u)" = "0" ]
+then
+  if [ ! -z "$WHD_EXTRA_PACKAGES" ]
+  then
+    # Accept a space or comma separated list of packages
+    packages=$(echo "$WHD_EXTRA_PACKAGES" | tr ',' ' ')
+
+    echo "Installing extra packages: $packages ..."
+    apk add --no-cache $packages
+    [ $? != 0 ] && die "Unable to install extra packages"
+  fi
+
+  # Re-exec as webhookd; unset so the second pass doesn't warn about the now-done install
+  unset WHD_EXTRA_PACKAGES
+  exec su-exec webhookd "$0" "$@"
+elif [ ! -z "$WHD_EXTRA_PACKAGES" ]
+then
+  echo "warning: WHD_EXTRA_PACKAGES is set but not running as root; skipping package installation" 1>&2
+fi
+
 if [ ! -z "$WHD_SCRIPTS_GIT_URL" ]
 then
   [ ! -f "$WHD_SCRIPTS_GIT_KEY" ] && die "Git clone key not found."

--- a/etc/default/webhookd.env
+++ b/etc/default/webhookd.env
@@ -71,3 +71,8 @@
 # Note: this is only used by the Docker image or by using the Docker entrypoint script
 # Example: `/etc/webhookd/github_deploy_key.pem`
 #WHD_SCRIPTS_GIT_KEY=
+# Extra packages to install (via apk) when the container starts
+# Note: this is only used by the Docker image or by using the Docker entrypoint script
+# Packages are installed at startup before the server drops to the unprivileged user
+# Example: `python3 py3-pip` or `python3,py3-pip`
+#WHD_EXTRA_PACKAGES=


### PR DESCRIPTION
Adds a new Docker env var: `WHD_EXTRA_PACKAGES` that when set installs those packages with apk on container launch.

This allows users to add the packages their scripts require (ruby, or gh-cli, or whatever) without having to fork the image, or add pre-installation sections to all of their scripts. I think this is a better solution to problems [like this one](https://github.com/ncarlier/webhookd/pull/110).

This did require changing the entrypoint script to initially run as root so it is able to install the packages with apk, the script then permanently drops to the unprivileged webhookd user before running the rest of the script and starting the server. (I believe this is the common approach used when an entrypoint needs to begin as root but does not want the whole docker running as root)